### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ JFS is built on top of the following projects
 
 ## Building JFS
 
-JFS has only been tested on Linux but it should be trivial to port to macOS.
+JFS has been tested on Linux and macOS.
 Windows support would likely require a lot more work and is dependent on getting
 LibFuzzer to work on Windows.
 

--- a/runtime/SMTLIB/SMTLIB/NativeFloat.cpp
+++ b/runtime/SMTLIB/SMTLIB/NativeFloat.cpp
@@ -156,7 +156,7 @@ bool jfs_nr_float64_is_negative(const jfs_nr_float64 value) {
   return value < jfs_nr_float64_get_zero(/*positive=*/false);
 }
 
-bool jfs_nr_float32_is_nan(const jfs_nr_float32 value) { return isnanf(value); }
+bool jfs_nr_float32_is_nan(const jfs_nr_float32 value) { return isnan(value); }
 
 bool jfs_nr_float64_is_nan(const jfs_nr_float64 value) { return isnan(value); }
 
@@ -191,8 +191,8 @@ bool jfs_nr_float32_smtlib_equals(const jfs_nr_float32 lhs,
       (check-sat)
       unsat
   */
-  bool lhsIsNaN = isnanf(lhs);
-  bool rhsIsNaN = isnanf(rhs);
+  bool lhsIsNaN = isnan(lhs);
+  bool rhsIsNaN = isnan(rhs);
   if (lhsIsNaN && rhsIsNaN) {
     return true;
   }

--- a/runtime/SMTLIB/SMTLIB/unittests/Float/Native/MakeFromIEEEBitVector.cpp
+++ b/runtime/SMTLIB/SMTLIB/unittests/Float/Native/MakeFromIEEEBitVector.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 #include "SMTLIB/Float.h"
 #include "gtest/gtest.h"
-#include <math.h>
+#include <cmath>
 
 TEST(MakeFromIEEEBitVector, PositiveZeroFloat32) {
   Float32 f(BitVector<32>(0x0));

--- a/runtime/SMTLIB/SMTLIB/unittests/Float/Native/SpecialConstants.cpp
+++ b/runtime/SMTLIB/SMTLIB/unittests/Float/Native/SpecialConstants.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 #include "SMTLIB/Float.h"
 #include "gtest/gtest.h"
-#include <math.h>
+#include <cmath>
 
 TEST(SpecialConstants, PositiveZeroFloat32) {
   Float32 zero = Float32::getPositiveZero();

--- a/scripts/dist/build_llvm.sh
+++ b/scripts/dist/build_llvm.sh
@@ -14,6 +14,8 @@ LLVM_BRANCH=release_60
 LLVM_GIT_URL="${LLVM_GIT_URL:-http://llvm.org/git/llvm.git}"
 CLANG_GIT_URL="${CLANG_GIT_URL:-http://llvm.org/git/clang.git}"
 COMPILER_RT_GIT_URL="${COMPILER_RT_GIT_URL:-http://llvm.org/git/compiler-rt.git}"
+LIBCXX_GIT_URL="${LIBCXX_GIT_URL:-http://git.llvm.org/git/libcxx.git}"
+LIBCXXABI_GIT_URL="${LIBCXX_GIT_URL:-http://git.llvm.org/git/libcxxabi.git}"
 
 ADDITIONAL_LLVM_OPTS=()
 
@@ -28,6 +30,13 @@ cd "${LLVM_SRC_DIR}/tools"
 git clone --depth 1 -b "${LLVM_BRANCH}" "${CLANG_GIT_URL}" "clang"
 cd "${LLVM_SRC_DIR}/projects"
 git clone --depth 1 -b "${LLVM_BRANCH}" "${COMPILER_RT_GIT_URL}" "compiler-rt"
+
+# Add libcxx and libcxxabi for macOS only
+# Ensures that the freshly built clang can find C++ headers on macOS
+if [[ "$OSTYPE" == darwin* ]]; then
+  git clone --depth 1 -b "${LLVM_BRANCH}" "${LIBCXX_GIT_URL}" "libcxx"
+  git clone --depth 1 -b "${LLVM_BRANCH}" "${LIBCXXABI_GIT_URL}" "libcxxabi"
+fi
 
 # Make build tree
 mkdir -p "${LLVM_BUILD_DIR}"


### PR DESCRIPTION
These commits fix up a few issues that were blocking JFS on macOS.

With these changes, all tests from `ninja check` are now passing on macOS.

Thanks for sharing this project! It seems like quite an interesting approach. :grin: